### PR TITLE
Fix AddAssignment bugs

### DIFF
--- a/src/main/java/seedu/address/logic/commands/FindCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FindCommand.java
@@ -38,7 +38,8 @@ public class FindCommand extends Command {
         requireNonNull(model);
         model.updateFilteredPersonList(predicate);
         return new CommandResult(
-                String.format(Messages.MESSAGE_PERSONS_LISTED_OVERVIEW, model.getFilteredPersonList().size()), CommandResult.ListPanelView.PERSON);
+                String.format(Messages.MESSAGE_PERSONS_LISTED_OVERVIEW, model.getFilteredPersonList().size()),
+                CommandResult.ListPanelView.PERSON);
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/FindCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FindCommand.java
@@ -38,7 +38,7 @@ public class FindCommand extends Command {
         requireNonNull(model);
         model.updateFilteredPersonList(predicate);
         return new CommandResult(
-                String.format(Messages.MESSAGE_PERSONS_LISTED_OVERVIEW, model.getFilteredPersonList().size()));
+                String.format(Messages.MESSAGE_PERSONS_LISTED_OVERVIEW, model.getFilteredPersonList().size()), CommandResult.ListPanelView.PERSON);
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/parser/AddAssignmentParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddAssignmentParser.java
@@ -32,6 +32,8 @@ public class AddAssignmentParser implements Parser<AddAssignmentCommand> {
         if (!arePrefixesPresent(argMultimap, PREFIX_DETAILS, PREFIX_AVAIL)) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddAssignmentCommand.MESSAGE_USAGE));
         }
+
+        argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_AVAIL, PREFIX_DETAILS);
         Index index;
 
         try {
@@ -41,8 +43,8 @@ public class AddAssignmentParser implements Parser<AddAssignmentCommand> {
                     AddAssignmentCommand.MESSAGE_USAGE), pe);
         }
 
-        Availability availability = new Availability(argMultimap.getValue(PREFIX_AVAIL).get());
-        AssignmentDetails details = new AssignmentDetails(argMultimap.getValue(PREFIX_DETAILS).get());
+        Availability availability = ParserUtil.parseAvailability(argMultimap.getValue(PREFIX_AVAIL).get());
+        AssignmentDetails details = ParserUtil.parseAssignmentDetails(argMultimap.getValue(PREFIX_DETAILS).get());
         return new AddAssignmentCommand(index, details, availability);
     }
 

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -9,6 +9,7 @@ import java.util.Set;
 import seedu.address.commons.core.index.Index;
 import seedu.address.commons.util.StringUtil;
 import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.assignment.AssignmentDetails;
 import seedu.address.model.person.Address;
 import seedu.address.model.person.Availability;
 import seedu.address.model.person.Email;
@@ -105,6 +106,19 @@ public class ParserUtil {
             availabilitiesSet.add(parseAvailability(availability));
         }
         return availabilitiesSet;
+    }
+
+    /**
+     * Parses {@code String Details} into a {@code AssignmentDetails}.
+     */
+    public static AssignmentDetails parseAssignmentDetails(String details) throws ParseException {
+        requireNonNull(details);
+        String trimmedDetails = details.trim();
+        if (!AssignmentDetails.isValidAssignmentDetails(trimmedDetails)) {
+            throw new ParseException(AssignmentDetails.MESSAGE_CONSTRAINTS);
+        }
+        AssignmentDetails assignmentDetails = new AssignmentDetails(trimmedDetails);
+        return assignmentDetails;
     }
 
     /**

--- a/src/main/java/seedu/address/model/assignment/AssignmentDetails.java
+++ b/src/main/java/seedu/address/model/assignment/AssignmentDetails.java
@@ -7,7 +7,7 @@ import static java.util.Objects.requireNonNull;
  */
 public class AssignmentDetails {
 
-    public static final String MESSAGE_CONSTRAINTS = "Assignment Details cannot be empty.";
+    public static final String MESSAGE_CONSTRAINTS = "Assignment Details must be alpha-numeric and not empty.";
     /*
      * The first character of the string must not be a whitespace,
      * otherwise " " (a blank string) becomes a valid input.

--- a/src/main/java/seedu/address/model/assignment/AssignmentDetails.java
+++ b/src/main/java/seedu/address/model/assignment/AssignmentDetails.java
@@ -6,6 +6,14 @@ import static java.util.Objects.requireNonNull;
  * Represents the details of the assignment
  */
 public class AssignmentDetails {
+
+    public static final String MESSAGE_CONSTRAINTS = "Assignment Details cannot be empty.";
+    /*
+     * The first character of the string must not be a whitespace,
+     * otherwise " " (a blank string) becomes a valid input.
+     */
+    public static final String VALIDATION_REGEX = "[\\p{Alnum}][\\p{Alnum} ]*";
+
     private String details;
 
     /**
@@ -15,6 +23,13 @@ public class AssignmentDetails {
     public AssignmentDetails(String details) {
         requireNonNull(details);
         this.details = details;
+    }
+
+    /**
+     * Returns true if given string is a valid Assignment Details.
+     */
+    public static boolean isValidAssignmentDetails(String test) {
+        return test.matches(VALIDATION_REGEX);
     }
 
     @Override

--- a/src/test/java/seedu/address/logic/commands/FindCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/FindCommandTest.java
@@ -62,7 +62,8 @@ public class FindCommandTest {
         NameContainsKeywordsPredicate predicate = preparePredicate(" ");
         FindCommand command = new FindCommand(predicate);
         expectedModel.updateFilteredPersonList(predicate);
-        assertCommandSuccess(command, model, expectedMessage, expectedModel);
+        assertCommandSuccess(command, model, expectedMessage, CommandResult.ListPanelView.PERSON,
+                expectedModel);
         assertEquals(Collections.emptyList(), model.getFilteredPersonList());
     }
 
@@ -72,7 +73,8 @@ public class FindCommandTest {
         NameContainsKeywordsPredicate predicate = preparePredicate("Kurz Elle Kunz");
         FindCommand command = new FindCommand(predicate);
         expectedModel.updateFilteredPersonList(predicate);
-        assertCommandSuccess(command, model, expectedMessage, expectedModel);
+        assertCommandSuccess(command, model, expectedMessage, CommandResult.ListPanelView.PERSON,
+                expectedModel);
         assertEquals(Arrays.asList(CARL, ELLE, FIONA), model.getFilteredPersonList());
     }
 
@@ -94,8 +96,10 @@ public class FindCommandTest {
             FindCommand command1 = new FindCommandParser().parse(" n/Kurz a/25/05/2024");
             FindCommand command2 = new FindCommandParser().parse(" a/25/05/2024 n/Kurz");
             expectedModel.updateFilteredPersonList(predicate1.or(predicate2));
-            assertCommandSuccess(command1, model, expectedMessage, expectedModel);
-            assertCommandSuccess(command2, model, expectedMessage, expectedModel);
+            assertCommandSuccess(command1, model, expectedMessage, CommandResult.ListPanelView.PERSON,
+                    expectedModel);
+            assertCommandSuccess(command2, model, expectedMessage, CommandResult.ListPanelView.PERSON,
+                    expectedModel);
             assertEquals(Arrays.asList(CARL, ELLE), model.getFilteredPersonList());
         } catch (Exception e) {
             e.printStackTrace();

--- a/src/test/java/seedu/address/logic/parser/AddAssignmentParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddAssignmentParserTest.java
@@ -52,6 +52,15 @@ public class AddAssignmentParserTest {
                 + VALID_AVAILABILITY_AMY, MESSAGE_INVALID_FORMAT);
     }
 
+    @Test
+    public void parse_duplicatePrefixTags() {
+        assertParseFailure(parser, "0" + VALID_ASSIGNMENT_DETAILS + VALID_ASSIGNMENT_DETAILS,
+                MESSAGE_INVALID_FORMAT);
+        assertParseFailure(parser, "0" + VALID_ASSIGNMENT_DETAILS + VALID_ASSIGNMENT_DETAILS
+                + VALID_AVAILABILITY_AMY,
+                MESSAGE_INVALID_FORMAT);
+    }
+
 
     private class AssignmentDetailsStub extends AssignmentDetails {
         private String details;

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -114,7 +114,7 @@ public class AddressBookParserTest {
     @Test
     public void parseCommand_addAssignment() throws Exception {
         String addAssignmentCommand = AddAssignmentCommand.COMMAND_WORD + " 1 " + PREFIX_DETAILS
-                + "VALID_DETAILS " + PREFIX_AVAIL + "01/01/2024";
+                + "VALIDDETAILS " + PREFIX_AVAIL + "01/01/2024";
         assertTrue(parser.parseCommand(addAssignmentCommand) instanceof AddAssignmentCommand);
     }
 

--- a/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
+++ b/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
@@ -193,4 +193,22 @@ public class ParserUtilTest {
 
         assertEquals(expectedTagSet, actualTagSet);
     }
+
+    @Test
+    public void parseInvalidAvailability_throwsParseException() throws Exception {
+        // not date format
+        assertThrows(ParseException.class, () -> ParserUtil.parseAvailability("not a date"));
+        assertThrows(ParseException.class, () -> ParserUtil.parseAvailability("02/02/2024/02"));
+
+        // should not be empty
+        assertThrows(ParseException.class, () -> ParserUtil.parseAvailability(""));
+    }
+
+    @Test
+    public void parseInvalidAssignmentDetails_throwsParseException() throws Exception {
+        // should be alphanumeric
+        assertThrows(ParseException.class, () -> ParserUtil.parseAssignmentDetails("*/2"));
+        // should not be empty
+        assertThrows(ParseException.class, () -> ParserUtil.parseAssignmentDetails(""));
+    }
 }


### PR DESCRIPTION
Fix #71 
Fix #72
Fix #77

Minor fixes to parser.


List of bugs fixed:
1.assign index d/details a/date
  a/date does not throw the invalid date format error. and causes illegalargumentexception

2.assign being able to take multiple keywords.

3.find command does not redirect to person's list while at assignment page

4.no parseDetails method in parseUtil